### PR TITLE
Set up Docker

### DIFF
--- a/bevangelista-website/Dockerfile
+++ b/bevangelista-website/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official node image as the base (Node version 20)
+FROM node:23-alpine
+
+# Set the working directory
+WORKDIR /bevangelista-website
+
+# Copy the package.json and package-lock.json files
+COPY package*.json ./
+
+# Install the dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the application port
+EXPOSE 3000
+
+# Start the application
+CMD ["npm", "start"]

--- a/bevangelista-website/docker-compose.yml
+++ b/bevangelista-website/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  frontend:
+    build: 
+      context: .
+      dockerfile: Dockerfile 
+    ports:
+      - "3000:3000"
+    develop:
+      watch:
+        - action: sync
+          path: .
+          target: /code
+    volumes:
+      - ./:/bevangelista-website
+      - /bevangelista-website/node_modules
+    command: "npm start"


### PR DESCRIPTION
## Description
Add Docker files to root directory so that project is tied to a Docker image, making it easier for development across OS and for eventual deployment.

## Changes to PR
- Add a Dockerfile with instructions for installing dependencies/exposing container to port 3000
- Add a docker-compose file for ease of spinning up/down the Docker container
  - Spin up docker image with `docker-compose up`, and terminate image with `docker-compose down`