### PR TITLE
Feat/add resume to frontend

### DIFF
--- a/backend/app/api/routes/routes.py
+++ b/backend/app/api/routes/routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
-from app.utils.gcs_client import list_files
+from app.utils.gcs_client import list_bucket_files, get_file_from_bucket
+from typing import Optional
 
 router = APIRouter()
 
@@ -19,5 +20,9 @@ APIs for GCP Cloud Storage
 '''
 gcpBaseEndpoint = "/external/gcp/cloudStorage"
 @router.get(f"{gcpBaseEndpoint}/list")
-def get_files():
-    return list_files()
+def list_files():
+    return list_bucket_files()
+
+@router.get(f"{gcpBaseEndpoint}/get")
+def get_file(file_name: str, prefix: Optional[str] = None):
+    return get_file_from_bucket(file_name, prefix)

--- a/backend/app/utils/gcs_client.py
+++ b/backend/app/utils/gcs_client.py
@@ -1,18 +1,44 @@
 import requests
+from typing import Optional
 from app.core.config import Config
+from fastapi import FastAPI, Response
+import urllib.parse
 
-BASE_URL = "https://storage.googleapis.com/storage/v1"
+app = FastAPI()
 
-def list_files() -> list[str]:
+BASE_URL = "https://storage.googleapis.com"
+
+def list_bucket_files() -> list[str]:
     """
     Fetches a list of files in a folder (prefix) in a GCS bucket.
     If no prefix is provided, lists all files in the bucket.
     """
-    url = f"{BASE_URL}/b/{Config.GCP_BUCKET_NAME}/o"
-    print(url)
+    url = f"{BASE_URL}/storage/v1/b/{Config.GCP_BUCKET_NAME}/o"
     params = { "key": Config.GCP_API_KEY }
 
     response = requests.get(url, params=params)
     response.raise_for_status()
 
     return response.json().get("items", [])
+
+def get_file_from_bucket(file_name: str, prefix: Optional[str] = None):
+    path_to_file = f"{prefix}/{file_name}" if prefix is not None else file_name
+    encoded_path = urllib.parse.quote(path_to_file, safe="")
+
+    url = f"{BASE_URL}/download/storage/v1/b/{Config.GCP_BUCKET_NAME}/o/{encoded_path}?alt=media"
+
+    params = { "key": Config.GCP_API_KEY }
+
+    response = requests.get(url, params=params, stream=True)
+    response.raise_for_status()
+
+    print(response)
+
+    content_type = response.headers.get("Content-Type", "application/octet-stream")
+    headers = {"Content-Disposition": f"attachment; filename={file_name}"}
+
+    return Response(
+        content=response.content,
+        media_type=content_type,
+        headers=headers
+    )

--- a/backend/app/utils/gcs_client.py
+++ b/backend/app/utils/gcs_client.py
@@ -32,10 +32,8 @@ def get_file_from_bucket(file_name: str, prefix: Optional[str] = None):
     response = requests.get(url, params=params, stream=True)
     response.raise_for_status()
 
-    print(response)
-
     content_type = response.headers.get("Content-Type", "application/octet-stream")
-    headers = {"Content-Disposition": f"attachment; filename={file_name}"}
+    headers = {"Content-Disposition": f"attachment; filename=\"{file_name}\""}
 
     return Response(
         content=response.content,

--- a/backend/tests/api/routes/test_gcp_routes.py
+++ b/backend/tests/api/routes/test_gcp_routes.py
@@ -2,13 +2,29 @@ from fastapi.testclient import TestClient
 from app.main import app
 from unittest.mock import patch
 
+from fastapi import Response
+
 client = TestClient(app)
 
-@patch("app.api.routes.routes.get_files")
-def test_get_files(mock_get_files):
-    mock_files_return = [{"name": "file1.txt"}, {"name": "file2.pdf"}, {"name": "file3.txt"}]
+@patch("app.api.routes.routes.list_files")
+def test_list_files(mock_list_files):
+    mock_list_files.return_value = [{"name": "file1.txt"}, {"name": "file2.pdf"}, {"name": "file3.txt"}]
 
     response = client.get("/external/gcp/cloudStorage/list")
 
     assert response.status_code == 200
-    assert len(list(response.json())) == len(mock_files_return)
+    assert len(list(response.json())) == len(mock_list_files.return_value)
+
+@patch("app.api.routes.routes.get_file")
+def test_get_file(mock_get_file):
+    mock_get_file.return_value = Response(
+        content=b"Mock file content",
+        media_type="application/pdf",
+        headers={"Content-Disposition": 'attachment; filename="Branden_Evangelista_Resume.pdf"'}
+    )
+
+    response = client.get("/external/gcp/cloudStorage/get",
+                          params={"file_name": "Branden_Evangelista_Resume.pdf", "prefix": "resume"})
+
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/pdf"

--- a/bevangelista-website/Dockerfile
+++ b/bevangelista-website/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install
 COPY . .
 
 # Expose the application port
-EXPOSE 3000
+EXPOSE 8080
 
 # Build and Start the application
 RUN npm run build

--- a/bevangelista-website/package.json
+++ b/bevangelista-website/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack -p 8080",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 8080",
     "lint": "next lint"
   },
   "dependencies": {

--- a/bevangelista-website/src/app/components/FileHandler.js
+++ b/bevangelista-website/src/app/components/FileHandler.js
@@ -1,0 +1,48 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import apiRoutes from "@/utils/apiRoutes";
+
+const FileHandler = (props)  => {
+    const [fileURL, setFileURL] = useState(null);
+    const [fileType, setFileType] = useState(null);
+    const [error, setError] = useState(null);
+
+    const downloadFile = async (fileName, prefix) => {
+        try {
+            const response = await fetch(apiRoutes.getFile(fileName, prefix));
+            const blob = await response.blob();
+            const url = URL.createObjectURL(blob);
+            setFileURL(url);
+            setFileType(blob.type);
+        } catch(error) {
+            console.error("Could not download file: ", error);
+            setError(error.message);
+            throw error;
+        }
+    }
+
+    useEffect(() => {
+        downloadFile(props.fileName, props.prefix);
+    }, [props]);
+
+    if (error) return <p style={{ color: "red" }}>Error: {error}</p>;
+    if (!fileURL) return <p>Loading file...</p>;
+
+    return (
+        <div>
+            {fileType?.includes("pdf") && (
+                <iframe src={fileURL} width="100%" height="600px" title="PDF Viewer"></iframe>
+            )}
+            {fileType?.includes("image") && <img src={fileURL} alt="File Preview" width="300px" />}
+            {fileType?.includes("text") && (
+                <iframe src={fileURL} width="100%" height="300px" title="Text Viewer"></iframe>
+            )}
+            {fileType && !fileType.includes("pdf") && !fileType.includes("image") && !fileType.includes("text") && (
+                <a href={fileURL} download>Download File</a>
+            )}
+        </div>
+    );
+}
+
+export default FileHandler;

--- a/bevangelista-website/src/app/components/FileHandler.js
+++ b/bevangelista-website/src/app/components/FileHandler.js
@@ -12,7 +12,9 @@ const FileHandler = (props)  => {
         try {
             const response = await fetch(apiRoutes.getFile(fileName, prefix));
             const blob = await response.blob();
+
             const url = URL.createObjectURL(blob);
+
             setFileURL(url);
             setFileType(blob.type);
         } catch(error) {
@@ -24,22 +26,24 @@ const FileHandler = (props)  => {
 
     useEffect(() => {
         downloadFile(props.fileName, props.prefix);
-    }, [props]);
+    }, [props.fileName, props.prefix]);
 
     if (error) return <p style={{ color: "red" }}>Error: {error}</p>;
     if (!fileURL) return <p>Loading file...</p>;
 
+    const srcURL = `${fileURL}#toolbar=0`
+
     return (
         <div>
-            {fileType?.includes("pdf") && (
-                <iframe src={fileURL} width="100%" height="600px" title="PDF Viewer"></iframe>
-            )}
-            {fileType?.includes("image") && <img src={fileURL} alt="File Preview" width="300px" />}
-            {fileType?.includes("text") && (
-                <iframe src={fileURL} width="100%" height="300px" title="Text Viewer"></iframe>
-            )}
-            {fileType && !fileType.includes("pdf") && !fileType.includes("image") && !fileType.includes("text") && (
-                <a href={fileURL} download>Download File</a>
+            {(fileType?.includes("pdf") ||
+                fileType?.includes("image") ||
+                fileType?.includes("text")) && (
+                <iframe
+                    src={srcURL}
+                    width={props.width}
+                    height={props.height}
+                >
+                </iframe>
             )}
         </div>
     );

--- a/bevangelista-website/src/app/resume/page.js
+++ b/bevangelista-website/src/app/resume/page.js
@@ -1,5 +1,12 @@
 import React from 'react'
+import FileHandler from '../components/FileHandler';
 
 export default function Resume() {
-    return <h1>Branden Evangelista - Resume</h1>;
+    return <h1>
+        Branden Evangelista - Resume
+        <FileHandler
+            fileName="Branden_Evangelista_Resume.pdf"
+            prefix="resume"
+        />
+    </h1>;
 }

--- a/bevangelista-website/src/app/resume/page.js
+++ b/bevangelista-website/src/app/resume/page.js
@@ -2,11 +2,14 @@ import React from 'react'
 import FileHandler from '../components/FileHandler';
 
 export default function Resume() {
-    return <h1>
-        Branden Evangelista - Resume
-        <FileHandler
-            fileName="Branden_Evangelista_Resume.pdf"
-            prefix="resume"
-        />
-    </h1>;
+    return (
+        <div style={{ display: "flex", justifyContent: "center" }}>
+            <FileHandler
+                fileName="Branden_Evangelista_Resume.pdf"
+                prefix="resume"
+                width="500px"
+                height="600px"
+            />
+        </div>
+    )
 }

--- a/bevangelista-website/src/utils/apiRoutes.js
+++ b/bevangelista-website/src/utils/apiRoutes.js
@@ -1,0 +1,8 @@
+const API_URL = "http://localhost:8000";
+
+const routes = {
+    listFiles: `${API_URL}/external/gcp/cloudStorage/list`,
+    getFile: (fileName, prefix) => `${API_URL}/external/gcp/cloudStorage/get?file_name=${fileName}&prefix=${prefix}`,
+};
+
+export default routes;

--- a/bevangelista-website/src/utils/apiRoutes.js
+++ b/bevangelista-website/src/utils/apiRoutes.js
@@ -1,4 +1,4 @@
-const API_URL = "http://localhost:8000";
+const API_URL = process.env.NEXT_PUBLIC_BACKEND_API_URL;
 
 const routes = {
     listFiles: `${API_URL}/external/gcp/cloudStorage/list`,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ./bevangelista-website
       dockerfile: Dockerfile
     ports:
-      - "3000:3000"
+      - "8080:8080"
     develop:
       watch:
         - action: sync


### PR DESCRIPTION
## Description
Use GCP API to pull resume from Cloud Storage bucket and display it on the frontend

## Changes in PR
- Create API to download file from Cloud Storage
- Create frontend component to take response from API and display it in an iframe
- Call new component in the `page.js` file of the `resume` folder
- Center div for resume