### PR TITLE
chore(github): add a template for PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Disclaimer: Before Raising the PR
+Before submitting your PR to merge to `main`, please ensure the following:
+1. All test cases pass
+2. Your branch is rebased with `main`. I will not be doing any merge commits or squash merges.
+   To ensure a clean commit history, please make sure your branch is rebased correctly.
+3. Your PR passes the GHA workflow. You can make any extra commits necessary to make sure that the workflows
+   succeed, but I will not be merging a branch that cannot pass all necessary workflows.
+
+## Description
+<!-- A brief description/summary of what this PR is for -->
+
+## Changes in this PR
+<!-- Add all changes in this PR in a bulleted list below -->
+- 
+- 
+- 


### PR DESCRIPTION
## Description
Creating a PR template to prevent blank descriptions when merging code.

## Changes in this PR
- A markdown file that has a basic template for describing all the changes in a raised PR. 