### PR TITLE
Refactor/dark mode

### DIFF
--- a/bevangelista-website/package-lock.json
+++ b/bevangelista-website/package-lock.json
@@ -8,9 +8,11 @@
       "name": "bevangelista-website",
       "version": "0.1.0",
       "dependencies": {
+        "moment": "^2.30.1",
         "next": "15.2.0-canary.74",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "suncalc": "^1.9.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -3901,6 +3903,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5318,6 +5329,11 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/suncalc": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/bevangelista-website/package.json
+++ b/bevangelista-website/package.json
@@ -9,15 +9,17 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "moment": "^2.30.1",
+    "next": "15.2.0-canary.74",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.2.0-canary.74"
+    "suncalc": "^1.9.0"
   },
   "devDependencies": {
-    "postcss": "^8",
-    "tailwindcss": "^3.4.1",
+    "@eslint/eslintrc": "^3",
     "eslint": "^9",
     "eslint-config-next": "15.2.0-canary.74",
-    "@eslint/eslintrc": "^3"
+    "postcss": "^8",
+    "tailwindcss": "^3.4.1"
   }
 }

--- a/bevangelista-website/src/app/about/page.js
+++ b/bevangelista-website/src/app/about/page.js
@@ -1,36 +1,12 @@
 "use client"
 
-import React, {useEffect, useState} from 'react'
 import Image from "next/image";
 import {IMAGE_CONSTANTS, ICON} from "@/utils/constants/constants";
 import NavBar from "@/app/components/NavBar";
+import { useDarkMode } from "@/context/DarkModeContext";
 
 export default function About() {
-    const [darkMode, setDarkMode] = useState(false);
-
-    useEffect(() => {
-        if (
-            localStorage.theme === "darkMode" ||
-            (
-                !("theme" in localStorage) &&
-                window.matchMedia("(prefers-color-scheme: dark)").matches
-            )
-        ) {
-            setDarkMode(true);
-        } else {
-            setDarkMode(false);
-        }
-    }, [])
-
-    useEffect(() => {
-        if (darkMode) {
-            document.documentElement.classList.add("dark");
-            localStorage.theme = 'dark';
-        } else {
-            document.documentElement.classList.remove("dark");
-            localStorage.theme = '';
-        }
-    }, [darkMode])
+    const { darkMode, setDarkMode } = useDarkMode();
 
     const aboutMeCards = [
         {icon: ICON.EDUCATION, iconDark: ICON.EDUCATION_DARK, title: "Education", description: "B.S in Computer Engineering and Minor in Mathematics"},
@@ -39,7 +15,7 @@ export default function About() {
 
     return (
         <>
-            <NavBar darkMode={darkMode} setDarkMode={setDarkMode} />
+            <NavBar />
 
             <div id="about" className="w-full px-[12%] py-10 pt-28 scroll-mt-20">
 

--- a/bevangelista-website/src/app/components/NavBar.jsx
+++ b/bevangelista-website/src/app/components/NavBar.jsx
@@ -1,8 +1,10 @@
 import React, { useRef } from 'react'
 import Image from "next/image";
-import {CONTACT, ICON, IMAGE_CONSTANTS} from "@/utils/constants/constants";
+import { CONTACT, ICON, IMAGE_CONSTANTS } from "@/utils/constants/constants";
+import { useDarkMode } from "@/context/DarkModeContext";
 
-const NavBar = ({ darkMode, setDarkMode }) => {
+const NavBar = () => {
+    const { darkMode, setDarkMode } = useDarkMode();
     const sideMenuRef = useRef();
 
     const openMenu = () => {

--- a/bevangelista-website/src/app/layout.js
+++ b/bevangelista-website/src/app/layout.js
@@ -1,7 +1,7 @@
 import { Outfit, Ovo } from "next/font/google";
 import "./globals.css";
 import { DarkModeProvider } from "@/context/DarkModeContext";
-import {IMAGE_CONSTANTS} from "@/utils/constants/constants";
+import { IMAGE_CONSTANTS } from "@/utils/constants/constants";
 
 const OutfitFont = Outfit({
     subsets: ["latin"],

--- a/bevangelista-website/src/app/layout.js
+++ b/bevangelista-website/src/app/layout.js
@@ -1,5 +1,6 @@
 import { Outfit, Ovo } from "next/font/google";
 import "./globals.css";
+import { DarkModeProvider } from "@/context/DarkModeContext";
 import {IMAGE_CONSTANTS} from "@/utils/constants/constants";
 
 const OutfitFont = Outfit({
@@ -26,7 +27,9 @@ export default function RootLayout({ children }) {
       <body
         className={`${OutfitFont.className} ${OvoFont.className} antialiased leading-8 overflow-x-hidden dark:bg-darkTheme dark:text-white`}
       >
-        {children}
+        <DarkModeProvider>
+            {children}
+        </DarkModeProvider>
       </body>
     </html>
   );

--- a/bevangelista-website/src/app/page.js
+++ b/bevangelista-website/src/app/page.js
@@ -1,39 +1,12 @@
 "use client"
 
-import { useState, useEffect } from "react";
 import NavBar from "./components/NavBar";
 import Header from "./components/Header";
 
 export default function Home() {
-    const [darkMode, setDarkMode] = useState(false);
-
-    useEffect(() => {
-        if (
-            localStorage.theme === "darkMode" ||
-            (
-                !("theme" in localStorage) &&
-                window.matchMedia("(prefers-color-scheme: dark)").matches
-            )
-        ) {
-            setDarkMode(true);
-        } else {
-            setDarkMode(false);
-        }
-    }, [])
-
-    useEffect(() => {
-        if (darkMode) {
-            document.documentElement.classList.add("dark");
-            localStorage.theme = 'dark';
-        } else {
-            document.documentElement.classList.remove("dark");
-            localStorage.theme = '';
-        }
-    }, [darkMode])
-
     return (
         <>
-            <NavBar darkMode={darkMode} setDarkMode={setDarkMode} />
+            <NavBar />
             <Header />
         </>
     );

--- a/bevangelista-website/src/context/DarkModeContext.js
+++ b/bevangelista-website/src/context/DarkModeContext.js
@@ -1,0 +1,40 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+const DarkModeContext = createContext();
+
+export const DarkModeProvider = ({ children }) => {
+    const [darkMode, setDarkMode] = useState(false);
+
+    // Initial load
+    useEffect(() => {
+        if (
+            localStorage.theme === "dark" ||
+            (!("theme" in localStorage) &&
+                window.matchMedia("(prefers-color-scheme: dark)").matches)
+        ) {
+            setDarkMode(true);
+        }
+    }, []);
+
+    // Sync with localStorage + html class
+    useEffect(() => {
+        if (darkMode) {
+            document.documentElement.classList.add("dark");
+            localStorage.theme = "dark";
+        } else {
+            document.documentElement.classList.remove("dark");
+            localStorage.theme = "";
+        }
+    }, [darkMode]);
+
+    return (
+        <DarkModeContext.Provider value={{ darkMode, setDarkMode }}>
+            {children}
+        </DarkModeContext.Provider>
+    );
+};
+
+// Custom hook for easy use
+export const useDarkMode = () => useContext(DarkModeContext);

--- a/bevangelista-website/src/context/DarkModeContext.js
+++ b/bevangelista-website/src/context/DarkModeContext.js
@@ -1,24 +1,64 @@
 "use client";
 
 import { createContext, useContext, useEffect, useState } from "react";
+import moment from "moment";
+import SunCalc from "suncalc";
 
 const DarkModeContext = createContext();
 
 export const DarkModeProvider = ({ children }) => {
     const [darkMode, setDarkMode] = useState(false);
 
-    // Initial load
-    useEffect(() => {
-        if (
-            localStorage.theme === "dark" ||
-            (!("theme" in localStorage) &&
-                window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-            setDarkMode(true);
+    const getUserCoordinates = () => {
+        return new Promise((resolve, reject) => {
+            if (!navigator.geolocation) {
+                reject(new Error("Geolocation is not available"));
+                return;
+            }
+
+            navigator.geolocation.getCurrentPosition((position) => {
+                resolve({
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                });
+            },
+                error => {
+                reject(new Error("Geolocation error: " + error.message));
+            });
+        });
+    }
+
+    const checkIfDarkMode = async () => {
+        try {
+            const { latitude, longitude } = await getUserCoordinates();
+            const now = moment().toDate();
+            const sunTimes = SunCalc.getTimes(now, latitude, longitude);
+
+            return !((now >= sunTimes.sunrise) && (now < sunTimes.sunset));
+        } catch (error) {
+            console.error(error.message);
+            return false;
         }
+    }
+
+    useEffect(() => {
+        async function initDarkMode() {
+            if (
+                localStorage.theme === "dark" ||
+                (!("theme" in localStorage) &&
+                    window.matchMedia("(prefers-color-scheme: dark)").matches)
+            ) {
+                setDarkMode(true);
+            }
+
+            const isDayTime = await checkIfDarkMode();
+            setDarkMode(isDayTime);
+        }
+
+        initDarkMode();
+
     }, []);
 
-    // Sync with localStorage + html class
     useEffect(() => {
         if (darkMode) {
             document.documentElement.classList.add("dark");
@@ -36,5 +76,4 @@ export const DarkModeProvider = ({ children }) => {
     );
 };
 
-// Custom hook for easy use
 export const useDarkMode = () => useContext(DarkModeContext);


### PR DESCRIPTION
## Description
<!-- A brief description/summary of what this PR is for -->
Add a `ContextProvider` for toggling dark mode, preventing the same code to be copy/pasted in multiple `page.js` files that require dark mode variables passed in as props.

## Changes in this PR
<!-- Add all changes in this PR in a bulleted list below -->
- Add a `DarkModeContext` provider that is wrapped around the root layout, allowing all pages to share the same dark mode functionality without passing in prop variables across different components.
- Use system time to set dark mode on first render
- Add `moment` and `suncalc` packages to check whether to enable dark mode after sunset
